### PR TITLE
Persist successful uploads to disk immediately

### DIFF
--- a/uploadr/uploadr.py
+++ b/uploadr/uploadr.py
@@ -382,6 +382,7 @@ class Uploadr:
         imageName = str( imageName )
         self.uploaded[ imageName ] = photoID
         self.uploaded[ photoID ] = imageName
+        self.uploaded.sync()
 
     def build_request(self, theurl, fields, files, txheaders=None):
         """


### PR DESCRIPTION
When uploading a large number of files (and fully expecting this process to die/fail before it finishes uploading all of them), it can be frustrating that the list of successfully uploaded files is stored only in an in-memory shelf object and is persisted only after an attempt to upload every file, in the call to self.uploaded.close().

This diff adds a call to self.uploaded.sync() on every logUpload(), which makes it much faster to fix in tangible form a copy of the fact that a file was uploaded successfully.
