### PR TITLE
docs: fix simple typo, insted -> instead

### DIFF
--- a/uploadr/uploadr.py
+++ b/uploadr/uploadr.py
@@ -217,7 +217,7 @@ class Uploadr:
         This method does not require authentication.
         Arguments
 
-        NTC: We need to store the token in a file so we can get it and then check it insted of
+        NTC: We need to store the token in a file so we can get it and then check it instead of
         getting a new on all the time.
 
         api.key (Required)


### PR DESCRIPTION
There is a small typo in uploadr/uploadr.py.

Should read `instead` rather than `insted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md